### PR TITLE
Fix bug with projects that use android.ndkVersion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ workflows:
             branches:
               only:
                 - "main"
+                - "bug/android-ndk-version"
           requires:
             - test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ aliases:
     docker:
       - image: circleci/android:api-29-node
     environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 
   - &release-filter
     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,6 @@ workflows:
             branches:
               only:
                 - "main"
-                - "bug/android-ndk-version"
           requires:
             - test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.1.1
+
+Bug Fixes
+
+- Fixed a bug where the measure task could not be executed with projects that set `android.ndkVersion`
+
 ### 0.1.0
 
 This release marks the first iteration of apkscale: a Gradle plugin to measure the app size impact of Android libraries.

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -29,7 +29,9 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                         MeasureAndroidLibrarySizeTask::class.java,
                         apkscaleExtension.abis,
                         libraryExtension.defaultConfig.minSdkVersion.apiLevel,
-                        libraryExtension.defaultConfig.targetSdkVersion.apiLevel)
+                        libraryExtension.defaultConfig.targetSdkVersion.apiLevel).apply {
+                    this.ndkVersion = libraryExtension.ndkVersion
+                }
 
                 // Ensure that measure task runs after assemble tasks
                 measureTask.mustRunAfter(project.tasks.named("assemble"))
@@ -43,6 +45,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
         }
     }
 
+    @VisibleForTesting internal var ndkVersion: String? = null
     private val outputAarDir = project.buildDir.resolve("outputs/aar")
     private val apkscaleDir = File("${project.buildDir}/apkscale")
     private val appMainDir = File("$apkscaleDir/src/main")
@@ -163,6 +166,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                 apply plugin: 'com.android.application'
                 android {
                   compileSdkVersion 29
+                  ${resolveNdkVersion()}
                   buildToolsVersion "29.0.2"
                   defaultConfig {
                       applicationId "com.twilio.apkscale"
@@ -205,6 +209,13 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                 }
                 """.trimIndent()
         )
+    }
+
+    @VisibleForTesting
+    internal fun resolveNdkVersion(): String {
+        return ndkVersion?.let {
+            "ndkVersion = \"$ndkVersion\""
+        } ?: ""
     }
 
     /*

--- a/src/test/kotlin/ApkscaleGradlePluginTest.kt
+++ b/src/test/kotlin/ApkscaleGradlePluginTest.kt
@@ -58,7 +58,6 @@ class ApkscaleGradlePluginTest {
     fun `it should provide empty output when there is no library built to measure`() {
         androidLibraryProject.writeBuildFile()
         val result = gradleRunner.withArguments(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME)
-                .withArguments(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME)
                 .build()
         assertMeasureTaskSucceeded(result)
         assertThat(getApkScaleReports()).isEmpty()
@@ -67,8 +66,7 @@ class ApkscaleGradlePluginTest {
     @Test
     fun `it should measure after assemble tasks`() {
         androidLibraryProject.writeBuildFile()
-        val result = gradleRunner.withArguments(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME)
-                .withArguments(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME, "assemble")
+        val result = gradleRunner.withArguments(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME, "assemble")
                 .build()
         assertMeasureTaskSucceeded(result)
         assertThat(getApkScaleReports()).isNotEmpty()
@@ -86,6 +84,15 @@ class ApkscaleGradlePluginTest {
          * the invocation of assembleRelease should only result in one report.
          */
         assertEquals(1, getApkScaleReports().size)
+    }
+
+    @Test
+    fun `it should allow projects that specify an ndkVersion`() {
+        androidLibraryProject.setNdkVersion("1.2.3")
+        androidLibraryProject.writeBuildFile()
+        val result = gradleRunner.withArguments("assemble", MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME)
+                .build()
+        assertMeasureTaskSucceeded(result)
     }
 
     @Test

--- a/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
+++ b/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
@@ -29,8 +29,8 @@ class MeasureAndroidLibrarySizeTaskTest {
     @Test
     @Parameters(method = "ndkVersionParameters")
     fun `resolveNdkVersion should return ndkVersion section`(
-            ndkVersion: String?,
-            expectedOutput: String
+        ndkVersion: String?,
+        expectedOutput: String
     ) {
         this.testNdkVersion = ndkVersion
         assertEquals(expectedOutput, measureAndroidLibrarySizeTask.resolveNdkVersion())

--- a/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
+++ b/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
@@ -15,12 +15,25 @@ class MeasureAndroidLibrarySizeTaskTest {
                 .build()
     }
     private val abis = mutableSetOf<String>()
+    private var testNdkVersion: String? = null
     private val measureAndroidLibrarySizeTask: MeasureAndroidLibrarySizeTask by lazy {
         project.tasks.create(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME,
                 MeasureAndroidLibrarySizeTask::class.java,
                 abis,
                 21,
-                29)
+                29).apply {
+            this.ndkVersion = testNdkVersion
+        }
+    }
+
+    @Test
+    @Parameters(method = "ndkVersionParameters")
+    fun `resolveNdkVersion should return ndkVersion section`(
+            ndkVersion: String?,
+            expectedOutput: String
+    ) {
+        this.testNdkVersion = ndkVersion
+        assertEquals(expectedOutput, measureAndroidLibrarySizeTask.resolveNdkVersion())
     }
 
     @Test
@@ -42,6 +55,15 @@ class MeasureAndroidLibrarySizeTaskTest {
     ) {
         this.abis.addAll(abis)
         assertEquals(expectedOutput, measureAndroidLibrarySizeTask.resolveApkAbiSuffix(abi))
+    }
+
+    // Test parameters
+    @Suppress("unused")
+    private fun ndkVersionParameters(): Array<Any>? {
+        return arrayOf(
+                arrayOf("1.2.3", "ndkVersion = \"1.2.3\""),
+                arrayOf(null, "")
+        )
     }
 
     // Test parameters

--- a/src/test/kotlin/util/AndroidLibraryProject.kt
+++ b/src/test/kotlin/util/AndroidLibraryProject.kt
@@ -6,7 +6,8 @@ class AndroidLibraryProject(
     private val projectFolder: TemporaryFolder = TemporaryFolder(),
     private val abis: MutableSet<String> = mutableSetOf(),
     private val buildTypes: MutableSet<String> = mutableSetOf(),
-    private val productFlavors: MutableSet<Pair<String, String>> = mutableSetOf()
+    private val productFlavors: MutableSet<Pair<String, String>> = mutableSetOf(),
+    private var ndkVersion: String? = null
 ) {
 
     fun setup() {
@@ -42,6 +43,10 @@ class AndroidLibraryProject(
         this.productFlavors.addAll(productFlavors)
     }
 
+    fun setNdkVersion(ndkVersion: String) {
+        this.ndkVersion = ndkVersion
+    }
+
     fun writeBuildFile() {
         projectFolder.newFile("build.gradle").apply {
             writeText(
@@ -63,6 +68,7 @@ class AndroidLibraryProject(
                 ${resolveApkscaleConfig()}
                 android {
                   compileSdkVersion 29
+                  ${resolveNdkVersion()}
                   buildToolsVersion "29.0.2"
                   defaultConfig {
                     minSdkVersion 21
@@ -87,6 +93,12 @@ class AndroidLibraryProject(
                 """.trimIndent()
             )
         }
+    }
+
+    private fun resolveNdkVersion(): String {
+        return ndkVersion?.let {
+            "ndkVersion = \"$ndkVersion\""
+        } ?: ""
     }
 
     private fun resolveApkscaleConfig(): String {


### PR DESCRIPTION
## Description

Allow library projects to set `android.ndkVersion`. This property is required with projects that need to specify a specific NDK version and do not use the environment variable `ANDROID_NDK_HOME`.

## Validation

- Added some additional testing to validate that this property can be specified
- [Validated with the Twilio Video Android SDK](https://app.circleci.com/pipelines/github/twilio/twilio-video-android/431/workflows/d854d72b-cab3-4356-9eba-2dca9b6e857f/jobs/21272) which recently switched from using `ANDROID_NDK_HOME`

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
