### PR TITLE
VIDEO-4344: Publish to MavenCentral

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,11 @@ aliases:
     environment:
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 
+  - &signing-key
+    name: Install signing key
+    command: >
+      echo $SIGNING_KEY | base64 -d >> $SIGNING_SECRET_KEY_RING_FILE
+
   - &release-filter
     filters:
       tags:
@@ -89,9 +94,19 @@ jobs:
       - attach_workspace:
           at: *workspace
       - restore_cache: *restore_cache-gradle
+      - run: *signing-key
       - run:
           name: Publish Apkscale Pre release
-          command: ./gradlew -q assemble artifactoryPublish -Djfrog.username=$APKSCALE_JFROG_OSS_USERNAME -Djfrog.password=$APKSCALE_JFROG_OSS_PASSWORD -PpreRelease=true
+          command: |
+            ./gradlew -q \
+            assemble \
+            artifactoryPublish \
+            -Dsigning.keyId=$SIGNING_KEY_ID \
+            -Dsigning.password=$SIGNING_PASSWORD \
+            -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
+            -Djfrog.username=$APKSCALE_JFROG_OSS_USERNAME \
+            -Djfrog.password=$APKSCALE_JFROG_OSS_PASSWORD \
+            -PpreRelease=true
       - save_cache: *save_cache-gradle
 
   publish-release:
@@ -102,9 +117,21 @@ jobs:
       - attach_workspace:
           at: *workspace
       - restore_cache: *restore_cache-gradle
+      - run: *signing-key
       - run:
           name: Publish Apkscale release
-          command: ./gradlew -q validateReleaseTag assemble bintrayUpload -Dbintray.username=$APKSCALE_BINTRAY_USERNAME -Dbintray.password=$APKSCALE_BINTRAY_PASSWORD
+          command: |
+            ./gradlew -q \
+            validateReleaseTag \
+            assemble \
+            publishApkscaleReleasePublicationToSonatypeRepository \
+            closeAndReleaseSonatypeStagingRepository \
+            -Dsigning.keyId=$SIGNING_KEY_ID \
+            -Dsigning.password=$SIGNING_PASSWORD \
+            -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
+            -DossrhUsername=$OSSRH_USERNAME \
+            -DossrhPassword=$OSSRH_PASSWORD \
+            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID
       - save_cache: *save_cache-gradle
 
   bump-version:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 .idea/
+
+local.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.1.2
+
+Enhancements
+
+- Now published to MavenCentral
+
 ### 0.1.1
 
 Bug Fixes
@@ -24,7 +30,7 @@ Add the following to your project's buildscript section.
 ```groovy
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     }
     classpath "com.twilio:apkscale:0.1.0"

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ A Gradle plugin to measure the app size impact of Android libraries.
 
 ## Usage
 
-[![Download](https://api.bintray.com/packages/twilio/releases/apkscale/images/download.svg) ](https://bintray.com/twilio/releases/apkscale/_latestVersion)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.twilio/apkscale/badge.svg) ](https://maven-badges.herokuapp.com/maven-central/com.twilio/apkscale)
 
 Add the following to your project's buildscript section.
 
 ```groovy
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
         // Include this line if you would like to use snapshots
         maven { url 'https://oss.jfrog.org/artifactory/libs-snapshot/' }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ buildscript {
     if(gitSha != null) return gitSha.substring(0, 7) else return ""
   }
 
+  ext["signing.keyId"] = System.getProperty('signing.keyId')
+  ext["signing.password"] = System.getProperty('signing.password')
+  ext["signing.secretKeyRingFile"] = System.getProperty('signing.secretKeyRingFile')
+
   repositories {
     google()
     jcenter()
@@ -24,8 +28,8 @@ plugins {
   id 'java-gradle-plugin'
   id 'maven-publish'
   id "com.diffplug.gradle.spotless" version "4.0.1"
+  id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
   id "com.jfrog.artifactory" version "4.15.2"
-  id "com.jfrog.bintray" version "1.8.5"
 }
 
 apply plugin: "com.diffplug.gradle.spotless"
@@ -49,6 +53,19 @@ repositories {
   maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
+nexusPublishing {
+  repositories {
+    sonatype {
+      username = System.getProperty('ossrhUsername')
+      password = System.getProperty('ossrhPassword')
+      stagingProfileId = System.getProperty('sonatypeStagingProfileId')
+    }
+  }
+
+  clientTimeout = Duration.ofSeconds(300)
+  connectTimeout = Duration.ofSeconds(60)
+}
+
 dependencies {
   implementation "org.gradle:gradle-tooling-api:6.5.1"
   implementation gradleApi()
@@ -64,6 +81,7 @@ dependencies {
 }
 
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 apply plugin: "com.jfrog.artifactory"
 
 tasks.register("sourcesJar", Jar).configure {
@@ -108,6 +126,12 @@ publishing {
             url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
           }
         }
+        developers {
+          developer {
+            id = 'Twilio'
+            name = 'Twilio'
+          }
+        }
         organization {
           name = 'Twilio, Inc.'
           url = 'https://www.twilio.com'
@@ -115,6 +139,10 @@ publishing {
       }
     }
   }
+}
+
+signing {
+  sign publishing.publications
 }
 
 artifactory {
@@ -132,26 +160,6 @@ artifactory {
     }
   }
   clientConfig.info.setBuildNumber(getShortCommitSha())
-}
-
-bintray {
-  user = System.getProperty('bintray.username')
-  key = System.getProperty('bintray.password')
-  publications = ['apkscaleRelease']
-  publish = true
-
-  pkg {
-    repo = 'releases'
-    name = 'apkscale'
-    userOrg = 'twilio'
-    licenses = ['Apache-2.0']
-    vcsUrl = 'https://github.com/twilio/apkscale'
-    version {
-      name = getVersionName()
-      desc = getVersionName()
-      released  = new Date()
-    }
-  }
 }
 
 /*
@@ -182,8 +190,10 @@ task validateReleaseTag {
 }
 
 afterEvaluate {
-  tasks.findByName("bintrayUpload").mustRunAfter("validateReleaseTag")
-  tasks.findByName("bintrayUpload").dependsOn("validateReleaseTag")
+  tasks.findByName("publishApkscaleReleasePublicationToSonatypeRepository").mustRunAfter("validateReleaseTag")
+  tasks.findByName("publishApkscaleReleasePublicationToSonatypeRepository").dependsOn("validateReleaseTag")
+  tasks.findByName("closeAndReleaseSonatypeStagingRepository").mustRunAfter("publishApkscaleReleasePublicationToSonatypeRepository")
+  tasks.findByName("closeAndReleaseSonatypeStagingRepository").dependsOn("publishApkscaleReleasePublicationToSonatypeRepository")
 }
 
 task incrementVersion() {


### PR DESCRIPTION
## Description

This PR publishes release builds to MavenCentral instead of Bintray/JCenter.

## Breakdown

- Updated `CHANGELOG.md` to note the change in publish location.
- Updated `README.md` to discuss the change in publish location.
- Updated `.circleci/config.yml` to read the signing key from the env variables and save it and updated the two publish task invocations as necessary to satisfy the signing requirements and the maven central publish tasks
- Configured `build.gradle` to configure for Maven Central publishing

## Validation

- Tested publishing locally to Artifactory OSS and Maven Central

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
