### PR TITLE
Fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Gradle plugin to measure the app size impact of Android libraries.
 
 ## Usage
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.twilio/apkscale/badge.svg) ](https://maven-badges.herokuapp.com/maven-central/com.twilio/apkscale)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.twilio/apkscale/badge.svg?style=svg)](https://maven-badges.herokuapp.com/maven-central/com.twilio/apkscale)
 
 Add the following to your project's buildscript section.
 

--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ task incrementVersion() {
 
       exec {
         workingDir "${rootDir}"
-        commandLine "git", "commit", "gradle.properties", "-m", "\"Bump patch version [skip ci]\""
+        commandLine "git", "commit", "gradle.properties", "-m", "\"Bump patch version\""
       }
 
       exec {


### PR DESCRIPTION
## Description

This PR fixes two things:

1. It appears after a release and the version bump that the CI badge always shows failed. I'm guessing it's because we skipped the last run and the badge doesn't like that?
2. Fixed the MavenCentral badge

## Breakdown

- Removed the `[skip ci]` in the patch bump task so that it still runs CI so the badge can report accurately.
- Fixed the MavenCentral badge link so it functions properly now.

## Validation

- 👀 

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
