### PR TITLE
Include a Library's Dependencies in Size Report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,11 +101,13 @@ jobs:
             ./gradlew \
             assemble \
             publishApkscaleReleasePublicationToSonatypeRepository \
+            closeAndReleaseSonatypeStagingRepository \
             -Dsigning.keyId=$SIGNING_KEY_ID \
             -Dsigning.password=$SIGNING_PASSWORD \
             -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
             -DossrhUsername=$OSSRH_USERNAME \
             -DossrhPassword=$OSSRH_PASSWORD \
+            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID \
             -PpreRelease=true
       - save_cache: *save_cache-gradle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,6 @@ workflows:
             branches:
               only:
                 - "main"
-                - "feature/transitive-dependencies"
           requires:
             - test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
         default: true
     steps:
       - run:
-          name: Publish Apkscale Pre Release (<< parameters.pre-release >>)
+          name: Publish Apkscale
           command: |
             ./gradlew \
             assemble \
@@ -132,20 +132,8 @@ jobs:
           at: *workspace
       - restore_cache: *restore_cache-gradle
       - run: *signing-key
-      - run:
-          name: Publish Apkscale release
-          command: |
-            ./gradlew -q \
-            validateReleaseTag \
-            assemble \
-            publishApkscaleReleasePublicationToSonatypeRepository \
-            closeAndReleaseSonatypeStagingRepository \
-            -Dsigning.keyId=$SIGNING_KEY_ID \
-            -Dsigning.password=$SIGNING_PASSWORD \
-            -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
-            -DossrhUsername=$OSSRH_USERNAME \
-            -DossrhPassword=$OSSRH_PASSWORD \
-            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID
+      - publish-artifact:
+          pre-release: false
       - save_cache: *save_cache-gradle
 
   bump-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,12 +100,14 @@ jobs:
           command: |
             ./gradlew -q \
             assemble \
-            artifactoryPublish \
+            publishApkscaleReleasePublicationToSonatypeRepository \
+            closeAndReleaseSonatypeStagingRepository \
             -Dsigning.keyId=$SIGNING_KEY_ID \
             -Dsigning.password=$SIGNING_PASSWORD \
             -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
-            -Djfrog.username=$APKSCALE_JFROG_OSS_USERNAME \
-            -Djfrog.password=$APKSCALE_JFROG_OSS_PASSWORD \
+            -DossrhUsername=$OSSRH_USERNAME \
+            -DossrhPassword=$OSSRH_PASSWORD \
+            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID \
             -PpreRelease=true
       - save_cache: *save_cache-gradle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,30 @@ aliases:
       branches:
         ignore: /.*/
 
+commands:
+  publish-artifact:
+    description: "Publish apkscale to Sonatype Repository"
+    parameters:
+      pre-release:
+        description: "A boolean value that indicates if the artifact is a release or pre release"
+        type: boolean
+        default: true
+    steps:
+      - run:
+          name: Publish Apkscale Pre Release (<< parameters.pre-release >>)
+          command: |
+            ./gradlew \
+            assemble \
+            publishApkscaleReleasePublicationToSonatypeRepository \
+            closeAndReleaseSonatypeStagingRepository \
+            -Dsigning.keyId=$SIGNING_KEY_ID \
+            -Dsigning.password=$SIGNING_PASSWORD \
+            -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
+            -DossrhUsername=$OSSRH_USERNAME \
+            -DossrhPassword=$OSSRH_PASSWORD \
+            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID \
+            -PpreRelease=<< parameters.pre-release >>
+
 jobs:
   check-format:
     <<: *build-defaults
@@ -95,20 +119,8 @@ jobs:
           at: *workspace
       - restore_cache: *restore_cache-gradle
       - run: *signing-key
-      - run:
-          name: Publish Apkscale Pre release
-          command: |
-            ./gradlew \
-            assemble \
-            publishApkscaleReleasePublicationToSonatypeRepository \
-            closeAndReleaseSonatypeStagingRepository \
-            -Dsigning.keyId=$SIGNING_KEY_ID \
-            -Dsigning.password=$SIGNING_PASSWORD \
-            -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
-            -DossrhUsername=$OSSRH_USERNAME \
-            -DossrhPassword=$OSSRH_PASSWORD \
-            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID \
-            -PpreRelease=true
+      - publish-artifact:
+          pre-release: true
       - save_cache: *save_cache-gradle
 
   publish-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: Publish Apkscale Pre release
           command: |
-            ./gradlew -q \
+            ./gradlew \
             assemble \
             publishApkscaleReleasePublicationToSonatypeRepository \
             closeAndReleaseSonatypeStagingRepository \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
   - &build-defaults
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-29-node
+      - image: circleci/android:api-30@sha256:04e8379f0701665ccf74a6f31d9c785b1aca451968087c9c9a626dd1015531d6
     environment:
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,13 +101,11 @@ jobs:
             ./gradlew \
             assemble \
             publishApkscaleReleasePublicationToSonatypeRepository \
-            closeAndReleaseSonatypeStagingRepository \
             -Dsigning.keyId=$SIGNING_KEY_ID \
             -Dsigning.password=$SIGNING_PASSWORD \
             -Dsigning.secretKeyRingFile=$SIGNING_SECRET_KEY_RING_FILE \
             -DossrhUsername=$OSSRH_USERNAME \
             -DossrhPassword=$OSSRH_PASSWORD \
-            -DsonatypeStagingProfileId=$SONATYPE_STAGING_PROFILE_ID \
             -PpreRelease=true
       - save_cache: *save_cache-gradle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
   - &build-defaults
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-30@sha256:04e8379f0701665ccf74a6f31d9c785b1aca451968087c9c9a626dd1015531d6
+      - image: circleci/android:api-30
     environment:
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,18 +155,17 @@ workflows:
     jobs:
       - check-format
       - build
-#      - test:
-#          requires:
-#            - build
-#            - check-format
+      - test:
+          requires:
+            - build
+            - check-format
       - publish-pre-release:
           filters:
             branches:
               only:
                 - "main"
-                - "feature/transitive-dependencies"
-#          requires:
-#            - test
+          requires:
+            - test
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,8 +165,8 @@ workflows:
               only:
                 - "main"
                 - "feature/transitive-dependencies"
-          requires:
-            - test
+#          requires:
+#            - test
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ workflows:
             branches:
               only:
                 - "main"
+                - "feature/transitive-dependencies"
           requires:
             - test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,6 @@ workflows:
             branches:
               only:
                 - "main"
-                - "feature/transitive-dependencies"
           requires:
             - test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,17 +155,18 @@ workflows:
     jobs:
       - check-format
       - build
-      - test:
-          requires:
-            - build
-            - check-format
+#      - test:
+#          requires:
+#            - build
+#            - check-format
       - publish-pre-release:
           filters:
             branches:
               only:
                 - "main"
-          requires:
-            - test
+                - "feature/transitive-dependencies"
+#          requires:
+#            - test
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,8 +165,8 @@ workflows:
               only:
                 - "main"
                 - "feature/transitive-dependencies"
-#          requires:
-#            - test
+          requires:
+            - test
 
   release:
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 0.1.3
+
+Enhancements
+
+- Added `humanReadable` configuration property that enables a user to toggle the use of `apkanalyzer` `--human-readable` flag. This property is `true` by default.
+
+```groovy
+apkscale {
+    humanReadable = false
+}
+```
+
+Bug Fixes
+
+- Apkscale now includes a library's dependencies in the size report. Fixes [#5](https://github.com/twilio/apkscale/issues/5).
+
 ### 0.1.2
 
 Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 0.1.3
 
+Updated Requirements
+
+- Using `apkscale` now requires Android Gradle Plugin 7.0.0+,  Gradle 7.0.0+, and Java 11
+
 Enhancements
 
 - Added `humanReadable` configuration property that enables a user to toggle the use of `apkanalyzer` `--human-readable` flag. This property is `true` by default.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A Gradle plugin to measure the app size impact of Android libraries.
 * Android SDK
 * Apkscale can only be applied within a `com.android.library` project.
 * [apkanalyzer](https://developer.android.com/studio/command-line/apkanalyzer) must be in your machine's path
-* Android Gradle Plugin 4.0.0+
+* Android Gradle Plugin 7.0.0+
+* Java 11
 
 ## Usage
 
@@ -25,7 +26,12 @@ buildscript {
         mavenCentral()
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
         // Include this line if you would like to use snapshots
-        maven { url 'https://oss.jfrog.org/artifactory/libs-snapshot/' }
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
     }
     // Append -SNAPSHOT for snapshot versions
     classpath "com.twilio:apkscale:$apkscaleVersion"
@@ -41,6 +47,9 @@ apply plugin: 'com.twilio.apkscale'
 apkscale {
     // Optional parameter to provide size reports for each ABI in addition to the default universal ABI
     abis = ['x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a']
+    
+    // Optional parameter to specify whether the output is human readable. Defaults to true.
+    humanReadable = true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ apply plugin: 'com.twilio.apkscale'
 apkscale {
     // Optional parameter to provide size reports for each ABI in addition to the default universal ABI
     abis = ['x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a']
-    
+
     // Optional parameter to specify whether the output is human readable. Defaults to true.
     humanReadable = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,7 @@ nexusPublishing {
       username = System.getProperty('ossrhUsername')
       password = System.getProperty('ossrhPassword')
       stagingProfileId = System.getProperty('sonatypeStagingProfileId')
-      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+      useStaging = false
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ repositories {
   google()
   jcenter()
   maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+  mavenCentral()
 }
 
 nexusPublishing {
@@ -65,16 +66,17 @@ nexusPublishing {
 }
 
 dependencies {
-  implementation "org.gradle:gradle-tooling-api:6.5.1"
+  implementation 'com.google.code.gson:gson:2.8.8'
+  implementation 'org.gradle:gradle-tooling-api:7.3-20210825160000+0000'
   implementation gradleApi()
-  implementation 'com.android.tools.build:gradle:4.0.0'
-  implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61'
+  implementation 'com.android.tools.build:gradle:7.0.2'
+  implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
 
-  runtimeOnly 'org.slf4j:slf4j-simple:1.7.10'
+  runtimeOnly 'org.slf4j:slf4j-simple:1.7.32'
 
   testImplementation gradleTestKit()
-  testImplementation 'junit:junit:4.12'
-  testImplementation 'com.google.truth:truth:1.0.1'
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'com.google.truth:truth:1.1.3'
   testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,8 @@ task validateReleaseTag {
 
   doLast {
     def circleTag = System.getenv("CIRCLE_TAG")
-    def tagsMatch = (matchesVersion(circleTag)) ? ("true") : ("false")
+    def preRelease = ((project.hasProperty("preRelease") && project.property("preRelease").toBoolean() == true)
+    def tagsMatch = (matchesVersion(circleTag) || preRelease) ? ("true") : ("false")
 
     exec {
       workingDir "${rootDir}"

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ nexusPublishing {
     sonatype {
       username = System.getProperty('ossrhUsername')
       password = System.getProperty('ossrhPassword')
-//      stagingProfileId = System.getProperty('sonatypeStagingProfileId')
+      stagingProfileId = System.getProperty('sonatypeStagingProfileId')
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ nexusPublishing {
       username = System.getProperty('ossrhUsername')
       password = System.getProperty('ossrhPassword')
       stagingProfileId = System.getProperty('sonatypeStagingProfileId')
+      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ nexusPublishing {
     sonatype {
       username = System.getProperty('ossrhUsername')
       password = System.getProperty('ossrhPassword')
-      stagingProfileId = System.getProperty('sonatypeStagingProfileId')
+//      stagingProfileId = System.getProperty('sonatypeStagingProfileId')
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ task validateReleaseTag {
 
   doLast {
     def circleTag = System.getenv("CIRCLE_TAG")
-    def preRelease = ((project.hasProperty("preRelease") && project.property("preRelease").toBoolean() == true)
+    def preRelease = (project.hasProperty("preRelease") && project.property("preRelease")).toBoolean()
     def tagsMatch = (matchesVersion(circleTag) || preRelease) ? ("true") : ("false")
 
     exec {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,7 @@
 buildscript {
+  ext.isPreRelease = (project.hasProperty("preRelease") && project.property("preRelease").toBoolean() == true)
   ext.getVersionName = {
-    return "${versionMajor}.${versionMinor}.${versionPatch}" +
-            ((project.hasProperty("preRelease") && project.property("preRelease").toBoolean() == true) ?
-                    "-SNAPSHOT" :
-                    '')
+    return "${versionMajor}.${versionMinor}.${versionPatch}" + (isPreRelease ? "-SNAPSHOT" : '')
   }
 
   ext.getShortCommitSha = {
@@ -58,7 +56,7 @@ nexusPublishing {
       username = System.getProperty('ossrhUsername')
       password = System.getProperty('ossrhPassword')
       stagingProfileId = System.getProperty('sonatypeStagingProfileId')
-      useStaging = false
+      useStaging = !isPreRelease
     }
   }
 
@@ -162,8 +160,7 @@ task validateReleaseTag {
 
   doLast {
     def circleTag = System.getenv("CIRCLE_TAG")
-    def preRelease = (project.hasProperty("preRelease") && project.property("preRelease")).toBoolean()
-    def tagsMatch = (matchesVersion(circleTag) || preRelease) ? ("true") : ("false")
+    def tagsMatch = (matchesVersion(circleTag) || isPreRelease) ? ("true") : ("false")
 
     exec {
       workingDir "${rootDir}"

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ plugins {
   id 'maven-publish'
   id "com.diffplug.gradle.spotless" version "4.0.1"
   id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
-  id "com.jfrog.artifactory" version "4.15.2"
 }
 
 apply plugin: "com.diffplug.gradle.spotless"
@@ -82,7 +81,6 @@ dependencies {
 
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: "com.jfrog.artifactory"
 
 tasks.register("sourcesJar", Jar).configure {
   group = JavaBasePlugin.DOCUMENTATION_GROUP
@@ -143,23 +141,6 @@ publishing {
 
 signing {
   sign publishing.publications
-}
-
-artifactory {
-  contextUrl = 'https://oss.jfrog.org'
-  publish {
-    repository {
-      repoKey = 'oss-snapshot-local'
-      username = System.getProperty('jfrog.username')
-      password = System.getProperty('jfrog.password')
-    }
-    defaults {
-      publications('apkscaleRelease')
-      publishArtifacts = true
-      publishPom = true
-    }
-  }
-  clientConfig.info.setBuildNumber(getShortCommitSha())
 }
 
 /*

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ nexusPublishing {
       username = System.getProperty('ossrhUsername')
       password = System.getProperty('ossrhPassword')
       stagingProfileId = System.getProperty('sonatypeStagingProfileId')
+      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
       snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 versionMajor=0
 versionMinor=1
-versionPatch=4
+versionPatch=3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 versionMajor=0
 versionMinor=1
-versionPatch=3
+versionPatch=4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 22 10:53:58 CDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 22 10:53:58 CDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/twilio/apkscale/ApkscaleExtension.kt
+++ b/src/main/kotlin/com/twilio/apkscale/ApkscaleExtension.kt
@@ -9,5 +9,10 @@ open class ApkscaleExtension(
      * to the universal ABI. By default this set is empty and Apkscale provides a size report for the
      * universal ABI.
      */
-    var abis: Set<String> = emptySet()
+    var abis: Set<String> = emptySet(),
+
+    /**
+     * If set to `true`, Apkscale will generate size reports in a human readable format. Defaults to `true`.
+     */
+    var humanReadable: Boolean = true
 )

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -86,13 +86,10 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
 
             // Assemble an apkscale release build
             val connection = GradleConnector.newConnector()
-                    .forProjectDirectory(project.rootDir)
+                    .forProjectDirectory(apkscaleDir)
                     .connect()
             connection.use {
-                it.newBuild()
-                    .withArguments("--include-build", apkscaleDir.absolutePath)
-                    .forTasks("assembleRelease")
-                    .run()
+                it.newBuild().forTasks("assembleRelease").run()
             }
 
             val sizeMap = mutableMapOf<String, String>()
@@ -232,7 +229,8 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                   mavenCentral()
                 }
                 dependencies {
-                    $dependencyConfiguration project(':${project.name}')
+                    ${resolveDependencies(dependencyConfiguration, aarLibraryFile)}
+                    $dependencyConfiguration files("${aarLibraryFile.absolutePath}")
                 }
                 """.trimIndent()
         )

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -86,11 +86,10 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
 
             // Assemble an apkscale release build
             val connection = GradleConnector.newConnector()
-                    .forProjectDirectory(project.rootDir)
+                    .forProjectDirectory(apkscaleDir)
                     .connect()
             connection.use {
                 it.newBuild()
-                    .withArguments("--include-build", apkscaleDir.absolutePath)
                     .forTasks("assembleRelease")
                     .run()
             }
@@ -154,6 +153,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
         )
         settingsFile.writeText(
                 """
+                includeBuild('${project.rootDir.absolutePath}')
                 include ':apkscale'
                 """.trimIndent()
         )

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -13,6 +13,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.tooling.GradleConnector
 
@@ -62,7 +63,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
         }
     }
 
-    @VisibleForTesting internal var ndkVersion: String? = null
+    @VisibleForTesting @Internal internal var ndkVersion: String? = null
     private val outputAarDir = project.buildDir.resolve("outputs/aar")
     private val apkscaleDir = File("${project.buildDir}/apkscale")
     private val appMainDir = File("$apkscaleDir/src/main")

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -180,16 +180,17 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                     mavenLocal()
                     google()
                     jcenter()
+                    mavenCentral()
                   }
                   dependencies {
-                    classpath 'com.android.tools.build:gradle:4.0.0'
+                    classpath 'com.android.tools.build:gradle:7.0.2'
                   }
                 }
                 apply plugin: 'com.android.application'
                 android {
-                  compileSdkVersion 29
+                  compileSdkVersion 30
                   ${resolveNdkVersion()}
-                  buildToolsVersion "29.0.2"
+                  buildToolsVersion "30.0.3"
                   defaultConfig {
                       applicationId "com.twilio.apkscale"
                       minSdkVersion $minSdkVersion
@@ -225,6 +226,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                   mavenLocal()
                   google()
                   jcenter()
+                  mavenCentral()
                 }
                 dependencies {
                     ${resolveDependencies(dependencyConfiguration, aarLibraryFile)}

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -2,7 +2,6 @@ package com.twilio.apkscale.tasks
 
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.LibraryVariant
-import com.google.common.annotations.VisibleForTesting
 import com.google.gson.Gson
 import com.twilio.apkscale.ApkscaleExtension
 import com.twilio.apkscale.model.ApkscaleReport
@@ -10,11 +9,12 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
-import org.gradle.api.DomainObjectCollection
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.tasks.TaskAction
 import org.gradle.tooling.GradleConnector
+import org.jetbrains.kotlin.com.google.common.annotations.VisibleForTesting
 
 private const val UNIVERSAL_ABI = "universal"
 
@@ -35,8 +35,8 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                     MeasureAndroidLibrarySizeTask::class.java,
                     apkscaleExtension.abis,
                     apkscaleExtension.humanReadable,
-                    libraryExtension.defaultConfig.minSdkVersion.apiLevel,
-                    libraryExtension.defaultConfig.targetSdkVersion.apiLevel,
+                    libraryExtension.defaultConfig.minSdkVersion?.apiLevel,
+                    libraryExtension.defaultConfig.targetSdkVersion?.apiLevel,
                     getVariantDependencies(libraryExtension.libraryVariants),
                     libraryExtension.ndkVersion ?: "")
 
@@ -51,7 +51,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
             }
         }
 
-        private fun getVariantDependencies(libraryVariants: DomainObjectCollection<LibraryVariant>): Map<String, DependencySet> {
+        private fun getVariantDependencies(libraryVariants: DomainObjectSet<LibraryVariant>): Map<String, DependencySet> {
             /*
              * Create a map of the library variants to the variant's dependencies so that apkscale pulls in the
              * correct dependencies for each variant that is measured.

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -86,10 +86,11 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
 
             // Assemble an apkscale release build
             val connection = GradleConnector.newConnector()
-                    .forProjectDirectory(apkscaleDir)
+                    .forProjectDirectory(project.rootDir)
                     .connect()
             connection.use {
                 it.newBuild()
+                    .withArguments("--include-build", apkscaleDir.absolutePath)
                     .forTasks("assembleRelease")
                     .run()
             }
@@ -153,7 +154,6 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
         )
         settingsFile.writeText(
                 """
-                includeBuild('${project.rootDir.absolutePath}')
                 include ':apkscale'
                 """.trimIndent()
         )

--- a/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
+++ b/src/main/kotlin/com/twilio/apkscale/tasks/MeasureAndroidLibrarySizeTask.kt
@@ -86,10 +86,13 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
 
             // Assemble an apkscale release build
             val connection = GradleConnector.newConnector()
-                    .forProjectDirectory(apkscaleDir)
+                    .forProjectDirectory(project.rootDir)
                     .connect()
             connection.use {
-                it.newBuild().forTasks("assembleRelease").run()
+                it.newBuild()
+                    .withArguments("--include-build", apkscaleDir.absolutePath)
+                    .forTasks("assembleRelease")
+                    .run()
             }
 
             val sizeMap = mutableMapOf<String, String>()
@@ -229,8 +232,7 @@ open class MeasureAndroidLibrarySizeTask @Inject constructor(
                   mavenCentral()
                 }
                 dependencies {
-                    ${resolveDependencies(dependencyConfiguration, aarLibraryFile)}
-                    $dependencyConfiguration files("${aarLibraryFile.absolutePath}")
+                    $dependencyConfiguration project(':${project.name}')
                 }
                 """.trimIndent()
         )

--- a/src/test/kotlin/ApkscaleGradlePluginTest.kt
+++ b/src/test/kotlin/ApkscaleGradlePluginTest.kt
@@ -113,7 +113,7 @@ class ApkscaleGradlePluginTest {
 
         assertThat(sizeReports).isNotEmpty()
 
-        assertThat(sizeReports.first().size["universal"]).matches("^\\d+$")
+        assertThat(sizeReports.first().size["universal"]).matches("^\\.*\\w+$")
     }
 
     @Test

--- a/src/test/kotlin/ApkscaleGradlePluginTest.kt
+++ b/src/test/kotlin/ApkscaleGradlePluginTest.kt
@@ -98,7 +98,7 @@ class ApkscaleGradlePluginTest {
 
         assertThat(sizeReports).isNotEmpty()
 
-        assertThat(sizeReports.first().size["universal"]).matches("^\\d+[.]\\d+\\w+$")
+        assertThat(sizeReports.first().size["universal"]).matches("^\\.*\\w+\$")
     }
 
     @Test
@@ -113,7 +113,7 @@ class ApkscaleGradlePluginTest {
 
         assertThat(sizeReports).isNotEmpty()
 
-        assertThat(sizeReports.first().size["universal"]).matches("^\\.*\\w+$")
+        assertThat(sizeReports.first().size["universal"]).matches("^\\d+$")
     }
 
     @Test

--- a/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
+++ b/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
@@ -13,20 +13,19 @@ import org.junit.runner.RunWith
 class MeasureAndroidLibrarySizeTaskTest {
     private val project by lazy {
         ProjectBuilder.builder()
-                .build()
+            .build()
     }
     private val abis = mutableSetOf<String>()
     private var testNdkVersion: String? = null
     private val measureAndroidLibrarySizeTask: MeasureAndroidLibrarySizeTask by lazy {
         project.tasks.create(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME,
-                MeasureAndroidLibrarySizeTask::class.java,
-                abis,
-                true,
-                21,
-                29,
-                emptyMap<String, DependencySet>()).apply {
-            this.ndkVersion = testNdkVersion
-        }
+            MeasureAndroidLibrarySizeTask::class.java,
+            abis,
+            true,
+            21,
+            29,
+            emptyMap<String, DependencySet>(),
+            testNdkVersion ?: "")
     }
 
     @Test
@@ -64,8 +63,8 @@ class MeasureAndroidLibrarySizeTaskTest {
     @Suppress("unused")
     private fun ndkVersionParameters(): Array<Any>? {
         return arrayOf(
-                arrayOf("1.2.3", "ndkVersion = \"1.2.3\""),
-                arrayOf(null, "")
+            arrayOf("1.2.3", "ndkVersion = \"1.2.3\""),
+            arrayOf(null, "")
         )
     }
 
@@ -73,9 +72,9 @@ class MeasureAndroidLibrarySizeTaskTest {
     @Suppress("unused")
     private fun apkSplitAbiParameters(): Array<Any>? {
         return arrayOf(
-                arrayOf(emptySet<String>(), ""),
-                arrayOf(setOf("arm64-v8a"), "include \"arm64-v8a\""),
-                arrayOf(setOf("arm64-v8a", "x86_64"), "include \"arm64-v8a\", \"x86_64\"")
+            arrayOf(emptySet<String>(), ""),
+            arrayOf(setOf("arm64-v8a"), "include \"arm64-v8a\""),
+            arrayOf(setOf("arm64-v8a", "x86_64"), "include \"arm64-v8a\", \"x86_64\"")
         )
     }
 
@@ -83,9 +82,9 @@ class MeasureAndroidLibrarySizeTaskTest {
     @Suppress("unused")
     private fun apkAbiSuffixParameters(): Array<Any>? {
         return arrayOf(
-                arrayOf(emptySet<String>(), "universal", "-"),
-                arrayOf(setOf("arm64-v8a"), "universal", "-universal-"),
-                arrayOf(setOf("x86_64"), "x86_64", "-x86_64-")
+            arrayOf(emptySet<String>(), "universal", "-"),
+            arrayOf(setOf("arm64-v8a"), "universal", "-universal-"),
+            arrayOf(setOf("x86_64"), "x86_64", "-x86_64-")
         )
     }
 }

--- a/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
+++ b/src/test/kotlin/tasks/MeasureAndroidLibrarySizeTaskTest.kt
@@ -4,6 +4,7 @@ import com.twilio.apkscale.tasks.MeasureAndroidLibrarySizeTask
 import junit.framework.Assert.assertEquals
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.gradle.api.artifacts.DependencySet
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,8 +21,10 @@ class MeasureAndroidLibrarySizeTaskTest {
         project.tasks.create(MeasureAndroidLibrarySizeTask.MEASURE_TASK_NAME,
                 MeasureAndroidLibrarySizeTask::class.java,
                 abis,
+                true,
                 21,
-                29).apply {
+                29,
+                emptyMap<String, DependencySet>()).apply {
             this.ndkVersion = testNdkVersion
         }
     }

--- a/src/test/kotlin/util/AndroidLibraryProject.kt
+++ b/src/test/kotlin/util/AndroidLibraryProject.kt
@@ -64,7 +64,7 @@ class AndroidLibraryProject(
                     mavenLocal()
                   }
                   dependencies {
-                    classpath 'com.android.tools.build:gradle:4.0.0'
+                    classpath 'com.android.tools.build:gradle:7.0.2'
                   }
                 }
                 plugins {
@@ -73,12 +73,12 @@ class AndroidLibraryProject(
                 }
                 ${resolveApkscaleConfig()}
                 android {
-                  compileSdkVersion 29
+                  compileSdkVersion 30
                   ${resolveNdkVersion()}
-                  buildToolsVersion "29.0.2"
+                  buildToolsVersion "30.0.3"
                   defaultConfig {
                     minSdkVersion 21
-                    targetSdkVersion 29
+                    targetSdkVersion 30
                   }
                   compileOptions {
                       sourceCompatibility 1.8
@@ -95,6 +95,7 @@ class AndroidLibraryProject(
                   mavenLocal()
                   google()
                   jcenter()
+                  mavenCentral()
                 }
                 dependencies {
                     ${resolveDependencies()}


### PR DESCRIPTION
## Description

* Query the dependencies of each library variant and build a map that apkscale uses to include any transitive dependencies in the apkscale app project used to measure.
* Add additional configuration property `humanReadable` to help validate the behavior of apkscale with dependencies. Fixes #5
* Remove publishing to Bintray snapshots repository as this is no longer supported. Update project to publish snapshot to maven central instead.
* Refactor artifact publishing to use one command
* Update all project dependencies 

## Validation

- Add a test that checks that a size report is larger with a variant that includes a dependency
- Add test cases for the new `humanReadable` property.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
