### PR TITLE
Use main (not master) as main branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   # this flag allows you to disable the default workflow, e.g. when running the standalone publish-snapshot workflow
   enable-default-workflow:
-    description: "enables the main workflow that builds and tests on all branches and publishes a snapshot on master"
+    description: "enables the main workflow that builds and tests on all branches and publishes a snapshot on main"
     type: boolean
     default: true
 
@@ -32,7 +32,7 @@ aliases:
     filters:
       branches:
         only:
-          - master
+          - main
 
 commands:
   restore_gradle_cache:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 <!-- Check the following before filing an issue -->
 > Before filing an issue please check the issue is not already addressed by the following:
 >  * [Github Issues](https://github.com/twilio/apkscale/issues)
->  * [Changelog](https://github.com/twilio/apkscale/blob/master/CHANGELOG.md)
+>  * [Changelog](https://github.com/twilio/apkscale/blob/main/CHANGELOG.md)
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 0.1.4 12/8/2021
+### 0.1.4 (December 9, 2021)
 
 Bug Fixes
 
@@ -9,7 +9,7 @@ Bug Fixes
 - Updated to use gradle 7.0.2 & android.build.tools 7.0.3
 - Updated the compileSDKVersion to 31
 
-### 0.1.3
+### 0.1.3 (September 13, 2021)
 
 Updated Requirements
 
@@ -29,19 +29,19 @@ Bug Fixes
 
 - Apkscale now includes a library's dependencies in the size report. Fixes [#5](https://github.com/twilio/apkscale/issues/5).
 
-### 0.1.2
+### 0.1.2 (March 5, 2021)
 
 Enhancements
 
 - Now published to MavenCentral
 
-### 0.1.1
+### 0.1.1 (August 28, 2020)
 
 Bug Fixes
 
 - Fixed a bug where the measure task could not be executed with projects that set `android.ndkVersion`
 
-### 0.1.0
+### 0.1.0 (July 28, 2020)
 
 This release marks the first iteration of apkscale: a Gradle plugin to measure the app size impact of Android libraries.
 


### PR DESCRIPTION
## Description

The `main` branch name was incorrectly referred to as `master` in build scripts and the bug template.

## Breakdown

- update snapshot filter in Circle CI config
- update bug report template
- add dates to older changelog entries

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
