### PR TITLE
[VBLOCKS-3475] Upgraded to Gradle 8.13 & AGP 8.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ### 0.1.8 (In development)
 
-- Upgrade to use gradle `8.13` and android.build.tools `8.12.2`.
+- Upgrade to use gradle `8.13` and android.build.tools `8.12.1`.
 
 ### 0.1.8 (Jun 30, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+### 0.1.8 (In development)
+
+- Upgrade to use gradle `8.13` and android.build.tools `8.12.2`.
+
 ### 0.1.8 (Jun 30, 2025)
 
 - No changes, internal test release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### 0.1.8 (In development)
+### 0.1.9 (In development)
 
 - Upgrade to use gradle `8.13` and android.build.tools `8.12.1`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ nexusPublishing {
 dependencies {
   implementation 'com.google.code.gson:gson:2.8.8'
   implementation gradleApi()
-  implementation 'com.android.tools.build:gradle-api:8.3.0'
-  implementation 'com.android.tools.build:gradle:8.3.0'
+  implementation 'com.android.tools.build:gradle-api:8.12.1'
+  implementation 'com.android.tools.build:gradle:8.12.1'
   implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
 
   testImplementation gradleTestKit()
@@ -149,7 +149,7 @@ def matchesVersion(versionTag) {
   return releaseTag == versionTag
 }
 
-task validateReleaseTag {
+tasks.register('validateReleaseTag') {
   description = 'Validate the release tag matches the release version present on commit'
 
   doLast {
@@ -170,7 +170,7 @@ afterEvaluate {
   tasks.findByName("closeAndReleaseSonatypeStagingRepository").dependsOn("publishApkscaleReleasePublicationToSonatypeRepository")
 }
 
-task incrementVersion() {
+tasks.register('incrementVersion') {
   description = 'Increment the version after a release'
 
   doLast {
@@ -181,7 +181,7 @@ task incrementVersion() {
       standardOutput stdOut
     }
 
-    def gitBranch = stdOut.toString().replaceAll("\\s","")
+    def gitBranch = stdOut.toString().replaceAll("\\s", "")
     def circleTag = System.getenv("CIRCLE_TAG")
     def nextVersionPatch = versionPatch.toInteger() + 1
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 22 10:53:58 CDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description
Upgrade to use Gradle 8.13 and AGP 8.12.1

## Breakdown

- Upgraded gradle to 8.13 from 8.4
- Upgraded AGP to 8.12.1.

## Validation

- Built and ran tests


## Additional Notes

Additional PRs may be needed after Twilio-video/voide-android are upgraded and test the usage of this tool is validated

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
