### PR TITLE
[VBLOCKS-3475] upgrade agp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ### 0.1.8 (In development)
 
-- Upgrade to use gradle `8.13` and android.build.tools `8.12.2`.
+- Upgrade to use gradle `8.13` and android.build.tools `8.12.1`.
 
 ### 0.1.8 (Jun 30, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 0.1.9 (In development)
 
 - Upgrade to use gradle `8.13` and android.build.tools `8.12.1`.
+- Fixed bug validating git tag matches release version name.
 
 ### 0.1.8 (Jun 30, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+### 0.1.8 (In development)
+
+- Upgrade to use gradle `8.13` and android.build.tools `8.12.2`.
+
 ### 0.1.8 (Jun 30, 2025)
 
 - No changes, internal test release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### 0.1.8 (In development)
+### 0.1.9 (In development)
 
 - Upgrade to use gradle `8.13` and android.build.tools `8.12.1`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -177,12 +177,6 @@ tasks.register('incrementVersion') {
             ?.replace('refs/remotes/origin/', '')
     def circleTag = System.getenv("CIRCLE_TAG")
     def nextVersionPatch = versionPatch.toInteger() + 1
-    def buildDirectory = layout.buildDirectory
-
-    // create build directory if it does not exist
-    if (!buildDirectory.get().asFile.exists()) {
-      buildDirectory.get().asFile.mkdir()
-    }
 
     // checkout the branch
     grgit.checkout(branch: gitBranch)

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ plugins {
   id 'maven-publish'
   id "com.diffplug.spotless" version '6.19.0'
   id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
+  id "org.ajoberstar.grgit" version "5.3.2"
 }
 
 apply plugin: "com.diffplug.spotless"
@@ -154,7 +155,7 @@ tasks.register('validateReleaseTag', Exec) {
   doFirst {
     def circleTag = System.getenv("CIRCLE_TAG")
     def tagsMatch = matchesVersion(circleTag) ? ("true") : ("false")
-    commandLine "echo", tagsMatch
+    commandLine tagsMatch
   }
   workingDir "${rootDir}"
 }
@@ -168,62 +169,45 @@ afterEvaluate {
 
 tasks.register('incrementVersion') {
   description = 'Increment the version after a release'
-
   doLast {
-    def stdOut = new ByteArrayOutputStream()
-
-    exec {
-      commandLine "bash", "-c", "git remote show origin | grep HEAD | cut -d: -f2-"
-      standardOutput stdOut
-    }
-
-    def gitBranch = stdOut.toString().replaceAll("\\s", "")
+    def gitBranch = grgit.repository.jgit.repository
+            .exactRef('refs/remotes/origin/HEAD')
+            ?.getTarget()
+            ?.getName()
+            ?.replace('refs/remotes/origin/', '')
     def circleTag = System.getenv("CIRCLE_TAG")
     def nextVersionPatch = versionPatch.toInteger() + 1
+    def buildDirectory = layout.buildDirectory
 
-    if (!buildDir.exists()) {
-      buildDir.mkdir()
+    // create build directory if it does not exist
+    if (!buildDirectory.get().asFile.exists()) {
+      buildDirectory.get().asFile.mkdir()
     }
 
-    exec {
-      workingDir "${rootDir}"
-      commandLine "git", "checkout", "${gitBranch}"
-    }
+    // checkout the branch
+    grgit.checkout(branch: gitBranch)
 
     /*
-     * Only update the version on upstream branch if the version matches tag. It is possible
-     * these values do not match if a job is performed on an earlier commit and a PR
-     * with a version update occurs later in history.
-     */
+    * Only update the version on upstream branch if the version matches tag. It is possible
+    * these values do not match if a job is performed on an earlier commit and a PR
+    * with a version update occurs later in history.
+    */
     if (matchesVersion(circleTag)) {
-      exec {
-        workingDir "${rootDir}"
-        commandLine "echo", "Incrementing from versionPatch ${versionPatch} to " +
-                "${nextVersionPatch}"
-      }
+        println "Incrementing from versionPatch ${versionPatch} to ${nextVersionPatch}"
 
-      exec {
-        workingDir "${rootDir}"
-        commandLine "sed",
-                "s@versionPatch=.*@versionPatch=${nextVersionPatch}@",
-                "gradle.properties"
-        standardOutput new FileOutputStream("${buildDir}/gradle.properties")
-      }
+        // update the version in gradle.properties
+        def gradlePropertiesFile = file('gradle.properties')
+        def properties = new Properties()
+        gradlePropertiesFile.withInputStream { properties.load(it) }
+        properties.setProperty("versionPatch", nextVersionPatch.toString())
+        gradlePropertiesFile.withOutputStream { properties.store(it, null) }
 
-      exec {
-        workingDir "${rootDir}"
-        commandLine "mv", "${buildDir}/gradle.properties", "gradle.properties"
-      }
+        // commit the change
+        grgit.add(patterns: ['gradle.properties'])
+        grgit.commit(message: 'Bump patch version')
 
-      exec {
-        workingDir "${rootDir}"
-        commandLine "git", "commit", "gradle.properties", "-m", "\"Bump patch version\""
-      }
-
-      exec {
-        workingDir "${rootDir}"
-        commandLine "git", "push", "origin", "${gitBranch}"
-      }
+        // push the change
+        grgit.push()
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -149,18 +149,14 @@ def matchesVersion(versionTag) {
   return releaseTag == versionTag
 }
 
-tasks.register('validateReleaseTag') {
+tasks.register('validateReleaseTag', Exec) {
   description = 'Validate the release tag matches the release version present on commit'
-
-  doLast {
+  doFirst {
     def circleTag = System.getenv("CIRCLE_TAG")
-    def tagsMatch = (matchesVersion(circleTag) || isPreRelease) ? ("true") : ("false")
-
-    exec {
-      workingDir "${rootDir}"
-      commandLine tagsMatch
-    }
+    def tagsMatch = matchesVersion(circleTag) ? ("true") : ("false")
+    commandLine "echo", tagsMatch
   }
+  workingDir "${rootDir}"
 }
 
 afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ nexusPublishing {
 dependencies {
   implementation 'com.google.code.gson:gson:2.8.8'
   implementation gradleApi()
-  implementation 'com.android.tools.build:gradle-api:8.3.0'
-  implementation 'com.android.tools.build:gradle:8.3.0'
+  implementation 'com.android.tools.build:gradle-api:8.12.1'
+  implementation 'com.android.tools.build:gradle:8.12.1'
   implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
 
   testImplementation gradleTestKit()
@@ -149,7 +149,7 @@ def matchesVersion(versionTag) {
   return releaseTag == versionTag
 }
 
-task validateReleaseTag {
+tasks.register('validateReleaseTag') {
   description = 'Validate the release tag matches the release version present on commit'
 
   doLast {
@@ -170,7 +170,7 @@ afterEvaluate {
   tasks.findByName("closeAndReleaseSonatypeStagingRepository").dependsOn("publishApkscaleReleasePublicationToSonatypeRepository")
 }
 
-task incrementVersion() {
+tasks.register('incrementVersion') {
   description = 'Increment the version after a release'
 
   doLast {
@@ -181,7 +181,7 @@ task incrementVersion() {
       standardOutput stdOut
     }
 
-    def gitBranch = stdOut.toString().replaceAll("\\s","")
+    def gitBranch = stdOut.toString().replaceAll("\\s", "")
     def circleTag = System.getenv("CIRCLE_TAG")
     def nextVersionPatch = versionPatch.toInteger() + 1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 versionMajor=0
 versionMinor=1
-versionPatch=8
+versionPatch=9

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 22 10:53:58 CDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

Removed depreciated way of doing things and fixed issue when attempting to release to maven

## Breakdown

- using 'exec' blocks is deprecated and replaced blocks by other means.
      -  using a git library instead of calling the cmd line
      - making an 'exec' task
- Updated version to 0.1.9      

## Validation

- Ran locally

## Additional Notes

None

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
